### PR TITLE
fix: Build with VC, use Array for dynamically allocated arrays

### DIFF
--- a/include/mirtk/BiasField.h
+++ b/include/mirtk/BiasField.h
@@ -239,7 +239,7 @@ inline double BiasField::Get(int index) const
 	int i, j, k;
 
 	if (index >= _x*_y*_z) {
-		std::cerr << "BiasField::Get: No such dof" << std::endl;
+		cerr << "BiasField::Get: No such dof" << endl;
 		exit(1);
 	}
 	i = index/(_y*_z);
@@ -251,7 +251,7 @@ inline double BiasField::Get(int index) const
 inline double BiasField::Get(int i, int j, int k) const
 {
 	if ((i < 0) || (i >= _x) || (j < 0) || (j >= _y) || (k < 0) || (k >= _z)) {
-		std::cerr << "BiasField::Get: No such dof" << std::endl;
+		cerr << "BiasField::Get: No such dof" << endl;
 		exit(1);
 	}
 	return _data[k][j][i];
@@ -263,7 +263,7 @@ inline void BiasField::Put(int index, double x)
 	int i, j, k;
 
 	if (index >= _x*_y*_z) {
-		std::cerr << "BiasField::Put: No such dof" << std::endl;
+		cerr << "BiasField::Put: No such dof" << endl;
 		exit(1);
 	}
 	i = index/(_y*_z);
@@ -275,7 +275,7 @@ inline void BiasField::Put(int index, double x)
 inline void BiasField::Put(int i, int j, int k, double x)
 {
 	if ((i < 0) || (i >= _x) || (j < 0) || (j >= _y) || (k < 0) || (k >= _z)) {
-		std::cerr << "BiasField::Put: No such dof" << std::endl;
+		cerr << "BiasField::Put: No such dof" << endl;
 		exit(1);
 	}
 	_data[k][j][i] = x;
@@ -338,9 +338,9 @@ inline void BiasField::PutBoundingBox(double x1, double y1, double z1, double x2
 
 	// Initialize control point spacing
 
-	_x = round((x2-x1)/_dx) +1;
-	_y = round((y2-y1)/_dy) +1;
-	_z = round((z2-z1)/_dz) +1;
+	_x = iround((x2-x1)/_dx) +1;
+	_y = iround((y2-y1)/_dy) +1;
+	_z = iround((z2-z1)/_dz) +1;
 	_dx = (x2 - x1) / (_x - 1);
 	_dy = (y2 - y1) / (_y - 1);
 	if (z2 > z1) {

--- a/include/mirtk/DrawEM.h
+++ b/include/mirtk/DrawEM.h
@@ -81,7 +81,7 @@ protected:
     RealImage **_MRF_inter;
 
     /// the tissue class of each label
-    int *tissuelabels;
+    Array<int> tissuelabels;
     int csflabel,wmlabel,gmlabel,outlabel;
 
 private:
@@ -178,14 +178,16 @@ inline void DrawEM::setMRFstrength(double mrfw){mrfweight=mrfw;}
 inline void DrawEM::setMRFInterAtlas(RealImage **&atlas){	_MRF_inter=atlas; intermrf=true;}
 inline void DrawEM::setBeta(double b){beta=b;}
 inline void DrawEM::setBetaInter(double b){betainter=b;}
-inline void DrawEM::setTissueLabels(int num,int *atisslabels){
-    tissuelabels=new int[num];
-    for(int i=0;i<num;i++)  tissuelabels[i]=atisslabels[i];
+
+inline void DrawEM::setTissueLabels(int num,int *atisslabels)
+{
+  tissuelabels.resize(num);
+  for (int i = 0; i < num; i++) {
+    tissuelabels[i] = atisslabels[i];
+  }
 }
 
-}
 
-
-
+} // namespace mirtk
 
 #endif /* DrawEM_H_ */

--- a/include/mirtk/EMBase.h
+++ b/include/mirtk/EMBase.h
@@ -23,6 +23,7 @@
 
 #include "mirtk/Image.h"
 #include "mirtk/Object.h"
+#include "mirtk/Array.h"
 #include "mirtk/HashProbabilisticAtlas.h"
 #include "mirtk/Gaussian.h"
 #include "mirtk/Histogram1D.h"
@@ -48,7 +49,7 @@ protected:
 	RealImage _brain;
 
 	/// weights image
-    RealImage _weights;
+  RealImage _weights;
 
 	/// image estimate
 	RealImage _estimate;
@@ -76,11 +77,11 @@ protected:
 	int _number_of_voxels;
 
 	/// Gaussian distribution parameters for each tissue type
-    Gaussian *_G;
-	double *_mi;
-	double *_sigma;
+  Array<Gaussian> _G;
+	Array<double> _mi;
+	Array<double> _sigma;
 	/// mixing coefficients for GMM
-	double *_c;
+	Array<double> _c;
 
 	/// Likelihood
 	double _f;
@@ -92,14 +93,14 @@ protected:
 	bool _has_background;
 
     /// superlabels
-	int *_super;
+	Array<int> _super;
 	bool _superlabels;
 
-    /// whether a mask is set
-    bool _mask_set;
+  /// whether a mask is set
+  bool _mask_set;
 
-    /// whether initial posteriors is set
-    bool _posteriors_set;
+  /// whether initial posteriors is set
+  bool _posteriors_set;
 
 public:
 	/// Input mask

--- a/include/mirtk/Gaussian.h
+++ b/include/mirtk/Gaussian.h
@@ -16,47 +16,47 @@
  * limitations under the License.
  */
 
+#ifndef _MIRTK_GAUSSIAN_H
+#define _MIRTK_GAUSSIAN_H
 
-#ifndef _MIRTKGAUSSIAN_H
+#include "mirtk/Object.h"
 
-#define _MIRTKGAUSSIAN_H
-
-#include "mirtk/Image.h"
-
-/**
-
-multivariate gaussian probability distribution
-
- */
 
 namespace mirtk {
 
+/**
+ * multivariate gaussian probability distribution
+ */
 class Gaussian : public Object
 {
 	mirtkObjectMacro(Gaussian);
 
 protected:
 
-	double _mi;
-	double _sigma;
+	double _mean;
+	double _var;
 	double _norm;
 
 public:
 
-	void Initialise(const double &mi, const double &sigma);
-	double Evaluate(const double &x);
-	double GetNorm();
+	void Initialise(double mean, double var);
+	double Evaluate(double x) const;
+	double GetNorm() const;
 };
 
-inline double Gaussian::Evaluate(const double &x)
+
+inline double Gaussian::Evaluate(double x) const
 {
-	return _norm * exp(-((x - _mi) * (x - _mi)) / (2.0 * _sigma));
+  x -= _mean;
+	return _norm * exp(-.5 * x*x / _var);
 }
 
-inline double Gaussian::GetNorm()
+inline double Gaussian::GetNorm() const
 {
 	return _norm;
 }
 
-}
-#endif
+
+} // namespace mirtk
+
+#endif // _MIRTK_GAUSSIAN_H

--- a/include/mirtk/Gaussian.h
+++ b/include/mirtk/Gaussian.h
@@ -20,6 +20,7 @@
 #define _MIRTK_GAUSSIAN_H
 
 #include "mirtk/Object.h"
+#include "mirtk/Math.h"
 
 
 namespace mirtk {

--- a/include/mirtk/HashProbabilisticAtlas.h
+++ b/include/mirtk/HashProbabilisticAtlas.h
@@ -154,7 +154,7 @@ inline void HashProbabilisticAtlas::Next(){
 inline RealPixel HashProbabilisticAtlas::GetValue(unsigned int mapnr){
 	if (mapnr < _images.size()) return _images[mapnr]->Get(_position);
 	else {
-		std::cerr << "map identificator " << mapnr <<" out of range." <<std::endl;
+		cerr << "map identificator " << mapnr <<" out of range." <<endl;
 		exit(1);
 	}
 }
@@ -162,7 +162,7 @@ inline RealPixel HashProbabilisticAtlas::GetValue(unsigned int mapnr){
 inline RealPixel HashProbabilisticAtlas::GetValue(int x, int y, int z, unsigned int mapnr){
 	if (mapnr < _images.size()) return _images[mapnr]->Get(x,y,z);
 	else {
-		std::cerr << "map identificator " << mapnr <<" out of range." <<std::endl;
+		cerr << "map identificator " << mapnr <<" out of range." <<endl;
 		exit(1);
 	}
 }
@@ -170,7 +170,7 @@ inline RealPixel HashProbabilisticAtlas::GetValue(int x, int y, int z, unsigned 
 inline void HashProbabilisticAtlas::SetValue(unsigned int mapnr, RealPixel value){
 	if (mapnr < _images.size()) _images[mapnr]->Put(_position, value);
 	else {
-		std::cerr << "map identificator " << mapnr << " out of range." <<std::endl;
+		cerr << "map identificator " << mapnr << " out of range." <<endl;
 		exit(1);
 	}
 }
@@ -178,7 +178,7 @@ inline void HashProbabilisticAtlas::SetValue(unsigned int mapnr, RealPixel value
 inline void HashProbabilisticAtlas::SetValue(int x, int y, int z, unsigned int mapnr, RealPixel value){
 	if (mapnr < _images.size()) _images[mapnr]->Put(x,y,z, value);
 	else {
-		std::cerr << "map identificator " << mapnr <<" out of range." <<std::endl;
+		cerr << "map identificator " << mapnr <<" out of range." <<endl;
 		exit(1);
 	}
 }
@@ -204,7 +204,7 @@ inline void HashProbabilisticAtlas::AddBackground(ImageType image){
 inline HashRealImage HashProbabilisticAtlas::GetImage(unsigned int mapnr) const{
     if (mapnr < _images.size()) return *_images[mapnr];
     else {
-        std::cerr << "map identificator " << mapnr <<" out of range." <<std::endl;
+        cerr << "map identificator " << mapnr <<" out of range." <<endl;
         exit(1);
     }
 }
@@ -213,7 +213,7 @@ inline HashRealImage::DataIterator HashProbabilisticAtlas::Begin(unsigned int ma
 {
     if (mapnr < _images.size()) return _images[mapnr]->Begin();
     else {
-        std::cerr << "map identificator " << mapnr <<" out of range." <<std::endl;
+        cerr << "map identificator " << mapnr <<" out of range." <<endl;
         exit(1);
     }
 }
@@ -221,7 +221,7 @@ inline HashRealImage::DataIterator HashProbabilisticAtlas::End(unsigned int mapn
 {
     if (mapnr < _images.size()) return _images[mapnr]->End();
     else {
-        std::cerr << "map identificator " << mapnr <<" out of range." <<std::endl;
+        cerr << "map identificator " << mapnr <<" out of range." <<endl;
         exit(1);
     }
 }

--- a/include/mirtk/ImageHistogram1D.h
+++ b/include/mirtk/ImageHistogram1D.h
@@ -37,7 +37,7 @@ protected:
 
 public:
 	/// Evaluate the histogram from a given image with padding value
-	virtual void Evaluate(GenericImage<VoxelType> *, VoxelType padding = -10000);
+	virtual void Evaluate(GenericImage<VoxelType> *, VoxelType padding = voxel_limits<VoxelType>::min_value);
 	/// Histogram Equalization
 	virtual void Equalize(VoxelType min,VoxelType max);
 	/// Back project the equalized histogram to image

--- a/include/mirtk/MeanShift.h
+++ b/include/mirtk/MeanShift.h
@@ -22,31 +22,29 @@
 // queue::push/pop
 
 #include "mirtk/GenericImage.h"
-#include "mirtk/Image.h"
 #include "mirtk/Dilation.h"
 #include "mirtk/Erosion.h"
-#include "mirtk/Point.h"
+#include "mirtk/Vector3D.h"
+#include "mirtk/Queue.h"
 #include "mirtk/GaussianBlurring.h"
-#include <algorithm>
-#include <queue>
 
-using namespace std;
 namespace mirtk {
 
 class MeanShift
 {
+  typedef Vector3D<int> Voxel;
 
 	int _nBins;
 	int _padding;
 	GreyImage _image;
-	queue<Point> _q;
+	Queue<Voxel> _q;
 	GreyImage _map, _orig_image;
 	GreyImage *_brain;
 	GreyImage *_output;
 	GreyPixel _imin, _imax;
 	double _limit1, _limit2, _limit, _treshold;
 	double _bin_width;
-	double * _density;
+	Array<double> _density;
 	int _clusterSize;
 public:
 	double _bg,_wm,_gm,_split1,_split2;
@@ -57,7 +55,7 @@ public:
 	MeanShift(GreyImage& image, int padding = -1, int nBins = 256);
 	~MeanShift();
 	void SetOutput( GreyImage *_output);
-	double ValueToBin(double value);
+	int ValueToBin(double value);
 	double BinToValue(int bin);
 	void AddPoint(int x, int y, int z);
 	void AddPoint(int x, int y, int z, int label);

--- a/include/mirtk/NormalizeNyul.h
+++ b/include/mirtk/NormalizeNyul.h
@@ -17,33 +17,42 @@
  */
 
 
-#ifndef MIRTKNORMALIZENYUL_H_
-#define MIRTKNORMALIZENYUL_H_
+#ifndef MIRTK_NORMALIZENYUL_H_
+#define MIRTK_NORMALIZENYUL_H_
 
-#include "mirtk/Image.h"
-//#include "mirtk/Registration.h"
-#include "mirtk/ImageHistogram1D.h"
+#include "mirtk/GenericImage.h"
 
 
 namespace mirtk {
 
-class NormalizeNyul{
 
+/**
+ * This filter implements the intensity normalization algorithm published in
+ *
+ * Nyul, L.G.; Udupa, J.K.; Xuan Zhang, "New variants of a method of MRI scale standardization",
+ * Medical Imaging, IEEE Transactions on , vol.19, no.2, pp.143-150, Feb 2000
+ * http://dx.doi.org/10.1109/42.836373 "
+ *
+ * Source code adapted from an implementation by Vladimir Fonov in EZminc (https://github.com/vfonov/EZminc)
+ */
+class NormalizeNyul
+{
 private:
 	RealImage _target;
 	RealImage _source;
-	int _source_padding;
-	int _target_padding;
+  double _source_padding;
+  double _target_padding;
 
 public:
 	NormalizeNyul(RealImage source, RealImage target);
 	void SetMask(RealImage source_mask, RealImage target_mask);
-	void SetPadding(int source_padding, int target_padding);
-	static void histogramImage(Histogram1D<RealPixel>* histogram, RealImage* image, double padding);
+	void SetPadding(double source_padding, double target_padding);
 	void Run();
 	RealImage GetOutput();
 	RealImage GetTarget();
 };
 
-}
-#endif
+
+} // namespace mirtk
+
+#endif // MIRTK_NORMALIZENYUL_H_

--- a/include/mirtk/ProbabilisticAtlas.h
+++ b/include/mirtk/ProbabilisticAtlas.h
@@ -137,7 +137,7 @@ inline RealPixel ProbabilisticAtlas::GetValue(unsigned int channel)
 {
 	if (channel < _images.size()) return *_pointers[channel];
 	else {
-		std::cerr << "Channel identificator " << channel <<" out of range." <<std::endl;
+		cerr << "Channel identificator " << channel <<" out of range." <<endl;
 		exit(1);
 	}
 }
@@ -146,7 +146,7 @@ inline RealPixel ProbabilisticAtlas::GetValue(int x, int y, int z, unsigned int 
 {
 	if (channel < _images.size()) return _images[channel].Get(x,y,z);
 	else {
-		std::cerr << "Channel identificator " << channel <<" out of range." <<std::endl;
+		cerr << "Channel identificator " << channel <<" out of range." <<endl;
 		exit(1);
 	}
 }
@@ -155,7 +155,7 @@ inline void ProbabilisticAtlas::SetValue(unsigned int channel, RealPixel value)
 {
 	if (channel < _images.size()) *_pointers[channel] = value;
 	else {
-		std::cerr << "Channel identificator " << channel << " out of range." <<std::endl;
+		cerr << "Channel identificator " << channel << " out of range." <<endl;
 		exit(1);
 	}
 }
@@ -164,7 +164,7 @@ inline void ProbabilisticAtlas::SetValue(int x, int y, int z, unsigned int chann
 {
 	if (channel < _images.size()) _images[channel].Put( x, y, z, value);
 	else {
-		std::cerr << "Channel identificator " << channel <<" out of range." <<std::endl;
+		cerr << "Channel identificator " << channel <<" out of range." <<endl;
 		exit(1);
 	}
 }

--- a/src/BSplineBiasField.cc
+++ b/src/BSplineBiasField.cc
@@ -130,17 +130,17 @@ BSplineBiasField::BSplineBiasField(const GreyImage &image, double dx, double dy,
 
 	// Initialize control point dimensions
 	if (x2 > x1) {
-		_x = round((x2 - x1) / dx) + 1;
+		_x = iround((x2 - x1) / dx) + 1;
 	} else {
 		_x = 1;
 	}
 	if (y2 > y1) {
-		_y = round((y2 - y1) / dy) + 1;
+		_y = iround((y2 - y1) / dy) + 1;
 	} else {
 		_y = 1;
 	}
 	if (z2 > z1) {
-		_z = round((z2 - z1) / dz) + 1;
+		_z = iround((z2 - z1) / dz) + 1;
 	} else {
 		_z = 1;
 	}
@@ -432,9 +432,9 @@ double BSplineBiasField::FFD1(double x, double y, double z) const
 	// Calculate offset
 	i = (_x + 8) * (_y + 4);
 	x = 0;
-	S = round(LUTSIZE*s);
-	T = round(LUTSIZE*t);
-	U = round(LUTSIZE*u);
+	S = iround(LUTSIZE*s);
+	T = iround(LUTSIZE*t);
+	U = iround(LUTSIZE*u);
 	data = &(_data[n-1][m-1][l-1]);
 	for (k = 0; k < 4; k++) {
 		B_K = this->LookupTable[U][k];
@@ -483,9 +483,9 @@ double BSplineBiasField::FFD2(double x, double y, double z) const
 	// Calculate offset
 	i = (_x + 8) * (_y + 4);
 	x = 0;
-	S = round(LUTSIZE*s);
-	T = round(LUTSIZE*t);
-	U = round(LUTSIZE*u);
+	S = iround(LUTSIZE*s);
+	T = iround(LUTSIZE*t);
+	U = iround(LUTSIZE*u);
 	data = &(_data[n-1][m-1][l-1]);
 	for (k = 0; k < 4; k++) {
 		B_K = this->LookupTable[U][k];

--- a/src/BiasCorrection.cc
+++ b/src/BiasCorrection.cc
@@ -60,17 +60,17 @@ void BiasCorrection::Run()
 	RealPixel *ptr2target, *ptr2ref, *ptr2w;
 
 	if (_reference == NULL) {
-		std::cerr << "BiasCorrection::Run: Filter has no reference input" << std::endl;
+		cerr << "BiasCorrection::Run: Filter has no reference input" << endl;
 		exit(1);
 	}
 
 	if (_target == NULL) {
-		std::cerr << "BiasCorrection::Run: Filter has no target input" << std::endl;
+		cerr << "BiasCorrection::Run: Filter has no target input" << endl;
 		exit(1);
 	}
 
 	if (_biasfield == NULL) {
-		std::cerr << "BiasCorrection::Run: Filter has no transformation output" << std::endl;
+		cerr << "BiasCorrection::Run: Filter has no transformation output" << endl;
 		exit(1);
 	}
 
@@ -119,11 +119,11 @@ void BiasCorrection::Run()
 		}
 	}
 
-	std::cout << "Computing bias field ... ";
-	std::cout.flush();
+	cout << "Computing bias field ... ";
+	cout.flush();
 	// _biasfield->Approximate(x, y, z, b, n);
 	_biasfield->WeightedLeastSquares(x, y, z, b, w, n);
-	std::cout << "done" << std::endl;
+	cout << "done" << endl;
 
 	delete []x;
 	delete []y;
@@ -165,8 +165,8 @@ void BiasCorrection::ApplyToImage(RealImage &image)
 {
 	int i, j, k;
 	double x, y, z, bias;
-	std::cerr<<"Applying bias ...";
-	//std::cerr<<_biasfield;
+	cerr<<"Applying bias ...";
+	//cerr<<_biasfield;
 
 	for (k = 0; k < image.GetZ(); k++) {
 		for (j = 0; j < image.GetY(); j++) {
@@ -184,7 +184,7 @@ void BiasCorrection::ApplyToImage(RealImage &image)
 		}
 	}
 
-	std::cerr<<"done."<<std::endl;
+	cerr<<"done."<<endl;
 }
 
 void BiasCorrection::ApplyToImage(GreyImage &image)
@@ -201,7 +201,7 @@ void BiasCorrection::ApplyToImage(GreyImage &image)
 				image.ImageToWorld(x, y, z);
 				bias = _biasfield->Bias(x, y, z);
 				if (image.Get(i, j, k) != _Padding) {
-					image(i, j, k) = round(image(i, j, k) / exp(bias/1000));
+					image(i, j, k) = static_cast<GreyPixel>(round(image(i, j, k) / exp(bias/1000)));
 				}
 			}
 		}

--- a/src/BiasField.cc
+++ b/src/BiasField.cc
@@ -95,15 +95,15 @@ double ***BiasField::Allocate(double ***data, int x, int y, int z)
 	}
 
 	if ((data = new double **[z+8]) == NULL) {
-		std::cerr << "Allocate: malloc failed for " << x << " x " << y << " x ";
-		std::cerr << z << "\n";
+		cerr << "Allocate: malloc failed for " << x << " x " << y << " x ";
+		cerr << z << "\n";
 		exit(1);
 	}
 	data += 4;
 
 	if ((data[-4] = new double *[(z+8)*(y+8)]) == NULL) {
-		std::cerr << "Allocate: malloc failed for " << x << " x " << y << " x ";
-		std::cerr << z << "\n";
+		cerr << "Allocate: malloc failed for " << x << " x " << y << " x ";
+		cerr << z << "\n";
 		exit(1);
 	}
 	data[-4] += 4;
@@ -113,8 +113,8 @@ double ***BiasField::Allocate(double ***data, int x, int y, int z)
 	}
 
 	if ((data[-4][-4] = new double[(z+8)*(y+8)*(x+8)]) == NULL) {
-		std::cerr << "Allocate: malloc failed for " << x << " x " << y << " x ";
-		std::cerr << z << "\n";
+		cerr << "Allocate: malloc failed for " << x << " x " << y << " x ";
+		cerr << z << "\n";
 		exit(1);
 	}
 	data[-4][-4] += 4;

--- a/src/DrawEM.cc
+++ b/src/DrawEM.cc
@@ -129,8 +129,8 @@ void DrawEM::RStep(double rf)
 
 
     int per = 0;
-    double* numerator = new double[_number_of_tissues];
-    double values[_number_of_tissues];
+    Array<double> numerator(_number_of_tissues);
+    Array<double> values(_number_of_tissues);
 
     for (int i=0; i< _number_of_voxels; i++){
         if (i*10.0/_number_of_voxels > per) {
@@ -181,7 +181,6 @@ void DrawEM::RStep(double rf)
         _atlas.Next();
         filteredAtlas.Next();
     }
-    delete[] numerator;
 }
 
 
@@ -225,8 +224,8 @@ int DrawEM::AddPartialVolumeClass(int classA, int classB, int huiclass)
         return -1;
     }
 
-    double* mi = new double[_number_of_tissues+1];
-    double* sigma = new double[_number_of_tissues+1];
+    Array<double> mi(_number_of_tissues+1);
+    Array<double> sigma(_number_of_tissues+1);
 
     mi[_number_of_tissues] = 0;
     sigma[_number_of_tissues] = 0;
@@ -284,19 +283,14 @@ int DrawEM::AddPartialVolumeClass(int classA, int classB, int huiclass)
         _output.Next();
     }
 
-    delete[] _mi;
-    delete[] _sigma;
-
     _number_of_tissues++;
-    _mi = new double[_number_of_tissues];
-    _sigma = new double[_number_of_tissues];
+    _mi.resize(_number_of_tissues);
+    _sigma.resize(_number_of_tissues);
     for( int k = 0; k < _number_of_tissues; ++k)
     {
         _mi[k] = mi[k];
         _sigma[k] = sigma[k];
     }
-    delete[] mi;
-    delete[] sigma;
 
     _atlas.AddImage(pvclass);
 
@@ -393,7 +387,7 @@ int DrawEM::AddPartialVolumeClass(int classA, int classB, int huiclass)
         //mine
         //pv_position = _number_of_tissues - 1;
     }
-    pv_classes.insert(make_pair(pv_position, pv_connections.size() ) );
+    pv_classes.insert(make_pair(pv_position, static_cast<int>(pv_connections.size()) ) );
 
     pv_connections.push_back( make_pair(classA, classB) );
     pv_fc.push_back(gamma);
@@ -402,19 +396,16 @@ int DrawEM::AddPartialVolumeClass(int classA, int classB, int huiclass)
     _connectivity.Print();
 
 
-    int *pretissuelabels=new int[_number_of_tissues-1];
+    Array<int> pretissuelabels(_number_of_tissues-1);
     for(int i=0;i<_number_of_tissues-1;i++){
         pretissuelabels[i]=tissuelabels[i];
     }
 
-    delete tissuelabels;
-    tissuelabels=new int[_number_of_tissues];
+    tissuelabels.resize(_number_of_tissues);
     for(int i=0;i<_number_of_tissues-1;i++){
         tissuelabels[i]=pretissuelabels[i];
     }
     tissuelabels[_number_of_tissues-1]=huiclass;
-
-
 
     return pv_position;
 }
@@ -553,8 +544,7 @@ void DrawEM::EStepMRF()
 
     int i, k;
     double x;
-    Gaussian* G = new Gaussian[_number_of_tissues];
-
+    Array<Gaussian> G(_number_of_tissues);
     for (k = 0; k < _number_of_tissues; k++) {
         G[k].Initialise( _mi[k], _sigma[k]);
     }
@@ -567,7 +557,7 @@ void DrawEM::EStepMRF()
     RealPixel *ptr = _input.GetPointerToVoxels();
     BytePixel *pm = _mask.GetPointerToVoxels();
     int per = 0;
-    double* numerator = new double[_number_of_tissues];
+    Array<double> numerator(_number_of_tissues);
     double denominator=0, temp=0;
     bool bMRF = _number_of_tissues == _connectivity.Rows();
 
@@ -584,7 +574,7 @@ void DrawEM::EStepMRF()
 
 
             x = *ptr;
-            double MRFenergies[_number_of_tissues];
+            Array<double> MRFenergies(_number_of_tissues);
             double denominatorMRF = .0;
 
             for (k = 0; k < _number_of_tissues; k++) {
@@ -670,9 +660,6 @@ void DrawEM::EStepMRF()
         _atlas.Next();
         _output.Next();
     }
-    delete[] numerator;
-    delete[] G;
-
 }
 
 
@@ -839,16 +826,16 @@ void DrawEM::huiPVCorrection(bool changePosterior){
     cc.Run();
 
 
-    int csfneighborswm[csfcomps];
-    int csfneighbors[csfcomps];
-    int csfneighborslven[csfcomps];
-    int csfneighborsrven[csfcomps];
+    Array<int> csfneighborswm(csfcomps);
+    Array<int> csfneighbors(csfcomps);
+    Array<int> csfneighborslven(csfcomps);
+    Array<int> csfneighborsrven(csfcomps);
     for (int i=0;i<csfcomps;i++){
         csfneighborswm[i]=0;csfneighbors[i]=0;csfneighborsrven[i]=0;csfneighborslven[i]=0;
     }
 
 
-    int wmvol[wmcomps];
+    Array<int> wmvol(wmcomps);
     for(int i=0;i<wmcomps;i++) wmvol[i]=0;
 
 

--- a/src/Gaussian.cc
+++ b/src/Gaussian.cc
@@ -17,7 +17,6 @@
  */
 
 #include "mirtk/Gaussian.h"
-#include "mirtk/Math.h"
 
 
 namespace mirtk {

--- a/src/Gaussian.cc
+++ b/src/Gaussian.cc
@@ -16,16 +16,20 @@
  * limitations under the License.
  */
 
-
 #include "mirtk/Gaussian.h"
+#include "mirtk/Math.h"
+
 
 namespace mirtk {
 
-void Gaussian::Initialise(const double &mi, const double &sigma)
+
+// ----------------------------------------------------------------------------
+void Gaussian::Initialise(double mean, double var)
 {
-	_mi = mi;
-	_sigma = sigma;
-	_norm = 1.0 / (sqrt(sigma) * sqrt(M_PI*2.0));
+	_mean = mean;
+	_var  = var;
+	_norm = 1. / (sqrt(_var) * sqrt(2.*pi));
 }
 
-}
+
+} // namespace std

--- a/src/HashProbabilisticAtlas.cc
+++ b/src/HashProbabilisticAtlas.cc
@@ -84,7 +84,7 @@ void HashProbabilisticAtlas::NormalizeAtlas(){
 	// normalize atlas to 0 to 1
 	this->First();
 	RealPixel norm;
-	RealPixel values[_number_of_maps];
+	Array<RealPixel> values(_number_of_maps);
 	for (i = 0; i < _number_of_voxels; i++) {
 		norm = 0;
 		for (j = 0; j < _number_of_maps; j++) {
@@ -118,7 +118,7 @@ void HashProbabilisticAtlas::AddBackground(){
 
 	// normalize atlas to 0 to 1
 	RealPixel norm, min, max, div, value;
-	RealPixel values[_number_of_maps];
+	Array<RealPixel> values(_number_of_maps);
 
 	HashRealImage *other;
 	other = _images[0];

--- a/src/HashProbabilisticAtlas.cc
+++ b/src/HashProbabilisticAtlas.cc
@@ -67,9 +67,8 @@ void HashProbabilisticAtlas::AddImage(ImageType image){
 		}
 	}
 	_images.push_back(new HashRealImage(image));
-	if(_has_background) SwapImages(_images.size()-2, _images.size()-1);
-	_number_of_maps = _images.size();
-
+	if(_has_background) SwapImages(static_cast<int>(_images.size())-2, static_cast<int>(_images.size())-1);
+	_number_of_maps = static_cast<int>(_images.size());
 }
 
 void HashProbabilisticAtlas::NormalizeAtlas(){

--- a/src/ImageHistogram1D.cc
+++ b/src/ImageHistogram1D.cc
@@ -45,15 +45,14 @@ template <class VoxelType> void ImageHistogram1D<VoxelType>::Evaluate(GenericIma
 
 template <class VoxelType> void ImageHistogram1D<VoxelType>::BackProject(GenericImage<VoxelType> *image)
 {  
-	VoxelType value;
+	double value;
 	int i,j,k,l;
 	for (l = 0; l < image->GetT(); l++){
 		for (k = 0; k < image->GetZ(); k++){
 			for (j = 0; j < image->GetY(); j++){
 				for (i = 0; i < image->GetX(); i++){
 					value = image->GetAsDouble(i, j, k, l);
-					value = this->ValToBin(value);
-					value = this->_bins[(int)round(value)];
+					value = this->BinToVal(this->ValToBin(value));
 					image->PutAsDouble(i,j,k,l,value);
 				}
 			}
@@ -63,15 +62,14 @@ template <class VoxelType> void ImageHistogram1D<VoxelType>::BackProject(Generic
 
 template <class VoxelType> void ImageHistogram1D<VoxelType>::Equalize(VoxelType min,VoxelType max)
 {
-	int i;
-	double count = 0,current;
-	for(i=0;i<this->_nbins;i++){
-        current = this->BinToPDF(i);
-		this->_bins[i] = (count+current/2.0)*(max - min) + min;
-        count += current;
+	double count = 0, current;
+	for(int i = 0; i < this->_nbins; ++i) {
+    current = this->BinToPDF(i);
+		this->_bins[i] = static_cast<VoxelType>((count + current/2.0) * (max - min) + min);
+    count += current;
 	}
-    this->_emin = min;
-    this->_emax = max;
+  this->_emin = min;
+  this->_emax = max;
 }
 
 template class ImageHistogram1D<unsigned char>;

--- a/src/KMeans.cc
+++ b/src/KMeans.cc
@@ -20,128 +20,129 @@
 
 #include "mirtk/KMeans.h"
 
-// Hard membership
-void kmeans::KMeansAssign()
-{
-	int winner;
-	double dist,distmin;
 
-	for(int i=0;i<n;i++)
-	{
-		distmin=DBL_MAX;
-		for(int j=0;j<k;j++)
-		{
-			dist=fabs(point[i]-centroid[j]);
+  // Hard membership
+  void kmeans::KMeansAssign()
+  {
+    int winner;
+    double dist, distmin;
 
-			if (dist<distmin) {distmin=dist; winner=j;}
-		}
-		pointcluster[i]=winner;
-		if(pointcluster[i] != oldpointcluster[i]){
-			converged=false;
-			oldpointcluster[i]=pointcluster[i];
-		}
-	}
-}
+    for (int i = 0; i < n; i++)
+    {
+      distmin = DBL_MAX;
+      for (int j = 0; j < k; j++)
+      {
+        dist = fabs(point[i] - centroid[j]);
 
+        if (dist < distmin) { distmin = dist; winner = j; }
+      }
+      pointcluster[i] = winner;
+      if (pointcluster[i] != oldpointcluster[i]) {
+        converged = false;
+        oldpointcluster[i] = pointcluster[i];
+      }
+    }
+  }
 
-void kmeans::KMeansCluster()
-{
-	int i,j,cl;
 
-	for(j=0;j<k;j++)
-	{
-		nb[j]=0;
-		centroid[j]=0;
-	}
+  void kmeans::KMeansCluster()
+  {
+    int i, j, cl;
 
-	for(i=0;i<n;i++)
-	{
-		cl=pointcluster[i];
-		centroid[cl]+=point[i];
-		nb[cl]++;
-	}
+    for (j = 0; j < k; j++)
+    {
+      nb[j] = 0;
+      centroid[j] = 0;
+    }
 
-	for(j=0;j<k;j++){
-		if (nb[j]>0) centroid[j]/=nb[j];
-	}
-}
+    for (i = 0; i < n; i++)
+    {
+      cl = pointcluster[i];
+      centroid[cl] += point[i];
+      nb[cl]++;
+    }
 
+    for (j = 0; j < k; j++) {
+      if (nb[j] > 0) centroid[j] /= nb[j];
+    }
+  }
 
 
-kmeans::kmeans(double *thepoints,int numpoints,int numclusters,int numiters,int replicates){
-	n=numpoints;
-	k=numclusters;
-	point=thepoints;
 
+  kmeans::kmeans(double *thepoints, int numpoints, int numclusters, int numiters, int replicates) {
+    n = numpoints;
+    k = numclusters;
+    point = thepoints;
 
-	nb=new int[k];
-	centroid=new double[k];
-	pointcluster=new int[n];
-	oldpointcluster=new int[n];
 
+    nb = new int[k];
+    centroid = new double[k];
+    pointcluster = new int[n];
+    oldpointcluster = new int[n];
 
-	bestsumdistances=DBL_MAX;
-	bestcentroid=new double[k];
-	bestpointcluster=new int[n];
 
-	double bestsumdistances0=DBL_MAX;
-	double *bestcentroid0=new double[k];
-	int *bestpointcluster0=new int[n];
+    bestsumdistances = DBL_MAX;
+    bestcentroid = new double[k];
+    bestpointcluster = new int[n];
 
+    double bestsumdistances0 = DBL_MAX;
+    double *bestcentroid0 = new double[k];
+    int *bestpointcluster0 = new int[n];
 
-	for(int rep=1;rep<=replicates;rep++){
-		for(int i=0;i<n;i++)
-			oldpointcluster[i]=-1;
 
-		for(int i=0;i<k;i++){
-			centroid[i]=point[rand()%n];
-		}
+    for (int rep = 1; rep <= replicates; rep++) {
+      for (int i = 0; i < n; i++)
+        oldpointcluster[i] = -1;
 
-		sort(centroid, centroid + k);
+      for (int i = 0; i < k; i++) {
+        centroid[i] = point[rand() % n];
+      }
 
+      sort(centroid, centroid + k);
 
 
-		for(int iter=1;iter<=numiters;iter++){
-			converged=true;
-			KMeansAssign();
-			KMeansCluster();
 
-			if(converged)break;
-		}
+      for (int iter = 1; iter <= numiters; iter++) {
+        converged = true;
+        KMeansAssign();
+        KMeansCluster();
 
-		std::sort(centroid, centroid + k);
-		KMeansAssign();
+        if (converged)break;
+      }
 
+      std::sort(centroid, centroid + k);
+      KMeansAssign();
 
-		double sumdistances=0;
-		for(int i=0;i<n;i++)
-			sumdistances+=fabs(point[i]-centroid[pointcluster[i]]);
 
+      double sumdistances = 0;
+      for (int i = 0; i < n; i++)
+        sumdistances += fabs(point[i] - centroid[pointcluster[i]]);
 
-		if(sumdistances<bestsumdistances0){
-			bestsumdistances0=sumdistances;
-			for(int i=0;i<n;i++) bestpointcluster0[i]=pointcluster[i];
-			for(int i=0;i<k;i++) bestcentroid0[i]=centroid[i];
-		}
 
-		bool zerofail=0;
-		for(int i=0;i<k;i++)if(nb[i]==0){
-			zerofail=true;
-			break;}
-		if(sumdistances<bestsumdistances && !zerofail){
-			bestsumdistances=sumdistances;
-			for(int i=0;i<n;i++) bestpointcluster[i]=pointcluster[i];
-			for(int i=0;i<k;i++) bestcentroid[i]=centroid[i];
-		}
-	}
+      if (sumdistances < bestsumdistances0) {
+        bestsumdistances0 = sumdistances;
+        for (int i = 0; i < n; i++) bestpointcluster0[i] = pointcluster[i];
+        for (int i = 0; i < k; i++) bestcentroid0[i] = centroid[i];
+      }
 
-	if(bestsumdistances==DBL_MAX){
-		bestsumdistances=bestsumdistances0;
-		for(int i=0;i<n;i++) bestpointcluster[i]=bestpointcluster0[i];
-		for(int i=0;i<k;i++) bestcentroid[i]=bestcentroid0[i];
-	}
-}
+      bool zerofail = 0;
+      for (int i = 0; i < k; i++)if (nb[i] == 0) {
+        zerofail = true;
+        break;
+      }
+      if (sumdistances < bestsumdistances && !zerofail) {
+        bestsumdistances = sumdistances;
+        for (int i = 0; i < n; i++) bestpointcluster[i] = pointcluster[i];
+        for (int i = 0; i < k; i++) bestcentroid[i] = centroid[i];
+      }
+    }
 
+    if (bestsumdistances == DBL_MAX) {
+      bestsumdistances = bestsumdistances0;
+      for (int i = 0; i < n; i++) bestpointcluster[i] = bestpointcluster0[i];
+      for (int i = 0; i < k; i++) bestcentroid[i] = bestcentroid0[i];
+    }
+  }
 
 
 
@@ -152,91 +153,93 @@ kmeans::kmeans(double *thepoints,int numpoints,int numclusters,int numiters,int 
 
 
 
-kmeans::kmeans(double *thepoints,int numpoints,int numclusters,double* centroids_init,int numiters,int replicates){
-	n=numpoints;
-	k=numclusters;
-	point=thepoints;
 
+  kmeans::kmeans(double *thepoints, int numpoints, int numclusters, double* centroids_init, int numiters, int replicates) {
+    n = numpoints;
+    k = numclusters;
+    point = thepoints;
 
 
 
-	nb=new int[k];
-	centroid=new double[k];
-	pointcluster=new int[n];
-	oldpointcluster=new int[n];
 
+    nb = new int[k];
+    centroid = new double[k];
+    pointcluster = new int[n];
+    oldpointcluster = new int[n];
 
-	bestsumdistances=DBL_MAX;
-	bestcentroid=new double[k];
-	bestpointcluster=new int[n];
 
-	double bestsumdistances0=DBL_MAX;
-	double *bestcentroid0=new double[k];
-	int *bestpointcluster0=new int[n];
+    bestsumdistances = DBL_MAX;
+    bestcentroid = new double[k];
+    bestpointcluster = new int[n];
 
-	double mindiff=1e10;
-	for(int i=0;i<k;i++){
-		for(int j=0;j<k;j++){
-			if(i==j)continue;
-			double diff=fabs(centroids_init[i]-centroids_init[j]);
-			if(diff<mindiff) mindiff=diff;
-		}
-	}
+    double bestsumdistances0 = DBL_MAX;
+    double *bestcentroid0 = new double[k];
+    int *bestpointcluster0 = new int[n];
 
+    double mindiff = 1e10;
+    for (int i = 0; i < k; i++) {
+      for (int j = 0; j < k; j++) {
+        if (i == j)continue;
+        double diff = fabs(centroids_init[i] - centroids_init[j]);
+        if (diff < mindiff) mindiff = diff;
+      }
+    }
 
-	int change=round(mindiff);
-	for(int rep=1;rep<=replicates;rep++){
-		for(int i=0;i<n;i++)
-			oldpointcluster[i]=-1;
 
-		for(int i=0;i<k;i++){
-			centroid[i]=centroids_init[i] + rand() % change;
-		}
+    int change = static_cast<int>(round(mindiff));
+    for (int rep = 1; rep <= replicates; rep++) {
+      for (int i = 0; i < n; i++)
+        oldpointcluster[i] = -1;
 
-		sort(centroid, centroid + k);
+      for (int i = 0; i < k; i++) {
+        centroid[i] = centroids_init[i] + rand() % change;
+      }
 
+      sort(centroid, centroid + k);
 
 
-		for(int iter=1;iter<=numiters;iter++){
-			converged=true;
-			KMeansAssign();
-			KMeansCluster();
 
-			if(converged)break;
-		}
+      for (int iter = 1; iter <= numiters; iter++) {
+        converged = true;
+        KMeansAssign();
+        KMeansCluster();
 
-		std::sort(centroid, centroid + k);
-		KMeansAssign();
+        if (converged)break;
+      }
 
+      std::sort(centroid, centroid + k);
+      KMeansAssign();
 
-		double sumdistances=0;
-		for(int i=0;i<n;i++)
-			sumdistances+=fabs(point[i]-centroid[pointcluster[i]]);
 
+      double sumdistances = 0;
+      for (int i = 0; i < n; i++)
+        sumdistances += fabs(point[i] - centroid[pointcluster[i]]);
 
-		if(sumdistances<bestsumdistances0){
-			bestsumdistances0=sumdistances;
-			for(int i=0;i<n;i++) bestpointcluster0[i]=pointcluster[i];
-			for(int i=0;i<k;i++) bestcentroid0[i]=centroid[i];
-		}
 
-		bool zerofail=0;
-		for(int i=0;i<k;i++)if(nb[i]==0){
-			zerofail=true;
-			break;}
-		if(sumdistances<bestsumdistances && !zerofail){
-			bestsumdistances=sumdistances;
-			for(int i=0;i<n;i++) bestpointcluster[i]=pointcluster[i];
-			for(int i=0;i<k;i++) bestcentroid[i]=centroid[i];
-		}
+      if (sumdistances < bestsumdistances0) {
+        bestsumdistances0 = sumdistances;
+        for (int i = 0; i < n; i++) bestpointcluster0[i] = pointcluster[i];
+        for (int i = 0; i < k; i++) bestcentroid0[i] = centroid[i];
+      }
 
-	}
+      bool zerofail = 0;
+      for (int i = 0; i < k; i++)if (nb[i] == 0) {
+        zerofail = true;
+        break;
+      }
+      if (sumdistances < bestsumdistances && !zerofail) {
+        bestsumdistances = sumdistances;
+        for (int i = 0; i < n; i++) bestpointcluster[i] = pointcluster[i];
+        for (int i = 0; i < k; i++) bestcentroid[i] = centroid[i];
+      }
 
-	if(bestsumdistances==DBL_MAX){
-		bestsumdistances=bestsumdistances0;
-		for(int i=0;i<n;i++) bestpointcluster[i]=bestpointcluster0[i];
-		for(int i=0;i<k;i++) bestcentroid[i]=bestcentroid0[i];
-	}
-}
+    }
 
-kmeans::kmeans(){}
+    if (bestsumdistances == DBL_MAX) {
+      bestsumdistances = bestsumdistances0;
+      for (int i = 0; i < n; i++) bestpointcluster[i] = bestpointcluster0[i];
+      for (int i = 0; i < k; i++) bestcentroid[i] = bestcentroid0[i];
+    }
+  }
+
+  kmeans::kmeans() {}

--- a/src/NormalizeNyul.cc
+++ b/src/NormalizeNyul.cc
@@ -18,175 +18,146 @@
 
 #include "mirtk/NormalizeNyul.h"
 
-/* "This program implements intensity normalization algorithm published in "
-       "Nyul, L.G.; Udupa, J.K.; Xuan Zhang, "
-       "\"New variants of a method of MRI scale standardization,\""
-       "Medical Imaging, IEEE Transactions on , vol.19, no.2, pp.143-150, Feb. 2000 "
-       "http://dx.doi.org/10.1109/42.836373 "
-
-    Source code adapted from an implementation by Vladimir Fonov in EZminc (https://github.com/vfonov/EZminc)
-
-       */
+#include "mirtk/ImageHistogram1D.h"
+#include "mirtk/CommonExport.h"
 
 
 namespace mirtk {
 
-NormalizeNyul::NormalizeNyul(RealImage source, RealImage target){
+
+// Verbose flag declared in Options.h of Common module
+MIRTK_Common_EXPORT int verbose;
+
+
+NormalizeNyul::NormalizeNyul(RealImage source, RealImage target)
+{
 	_source = source;
 	_target = target;
-	_source_padding = 0;
-	_target_padding = 0;
+	_source_padding = 0.;
+	_target_padding = 0.;
 }
 
 
-void NormalizeNyul::SetMask(RealImage source_mask, RealImage target_mask){
+void NormalizeNyul::SetMask(RealImage source_mask, RealImage target_mask)
+{
 	RealPixel * iPtr, *mPtr;
 	iPtr = _source.GetPointerToVoxels();
 	mPtr = source_mask.GetPointerToVoxels();
-	for(int i = 0; i < _source.GetNumberOfVoxels(); i++){
-		if(*mPtr<1){
-			*iPtr = _source_padding;
+	for (int i = 0; i < _source.GetNumberOfVoxels(); ++i) {
+		if (*mPtr < 1) {
+			*iPtr = voxel_cast<RealPixel>(_source_padding);
 		}
 		iPtr++;
 		mPtr++;
 	}
 	iPtr = _target.GetPointerToVoxels();
 	mPtr = source_mask.GetPointerToVoxels();
-	for(int i = 0; i < _target.GetNumberOfVoxels(); i++){
-		if(*mPtr<1){
-			*iPtr = _target_padding;
+	for (int i = 0; i < _target.GetNumberOfVoxels(); ++i) {
+		if (*mPtr < 1) {
+			*iPtr = voxel_cast<RealPixel>(_target_padding);
 		}
 		iPtr++;
 		mPtr++;
 	}
 }
 
-RealImage NormalizeNyul::GetOutput(){
+RealImage NormalizeNyul::GetOutput()
+{
 	return _source;
 }
 
-RealImage NormalizeNyul::GetTarget(){
+RealImage NormalizeNyul::GetTarget()
+{
 	return _target;
 }
 
-void NormalizeNyul::SetPadding(int source_padding, int target_padding){
+void NormalizeNyul::SetPadding(double source_padding, double target_padding)
+{
 	_source_padding = source_padding;
 	_target_padding = target_padding;
 }
 
-void NormalizeNyul::Run(){
-	   int verbose=0;
-//	  int normalize=0;
-//	  int bimodalT=0;
-//	  int debug=0;
-	  int hist_bins=4000;
-	  int steps=10;
-//	  int clobber=0;
-//	  int fix_zero_padding=0;
+void NormalizeNyul::Run()
+{
+  const int    hist_bins = 4000;
+  const int    steps     = 10;
+	const double cut_off   = .01;
+  const double step      = (1.0 - 2.0*cut_off / 100.0) / steps;
 
-	  double cut_off=0.01;
-	  float src_min,src_max;
-	  float trg_min,trg_max;
+	ImageHistogram1D<RealPixel> src_hist_s, trg_hist_s;
+	src_hist_s.PutNumberOfBins(hist_bins);
+	trg_hist_s.PutNumberOfBins(hist_bins);
+	src_hist_s.Evaluate(&_source, static_cast<RealPixel>(_source_padding));
+	trg_hist_s.Evaluate(&_target, static_cast<RealPixel>(_target_padding));
 
-	  ImageHistogram1D<RealPixel> src_hist_s, trg_hist_s;
+	const double src_min = src_hist_s.GetMin();
+  const double src_max = src_hist_s.GetMax();
+  const double trg_min = trg_hist_s.GetMin();
+  const double trg_max = trg_hist_s.GetMax();
 
-	  src_hist_s.PutNumberOfBins(hist_bins);
-	  trg_hist_s.PutNumberOfBins(hist_bins);
-
-	  src_hist_s.Evaluate(&_source,_source_padding);
-	  trg_hist_s.Evaluate(&_target,_target_padding);
-
-	  src_min = src_hist_s.GetMin();
-	  src_max = src_hist_s.GetMax();
-
-	  trg_min = trg_hist_s.GetMin();
-	  trg_max = trg_hist_s.GetMax();
-
-	  double step  = (1.0 - 2.0*cut_off/100.0) / steps ;
-
-	  std::vector<double> src_levels_s;
-	  std::vector<double> trg_levels_s;
-
-	  //provide mapping for background
-	  src_levels_s.push_back(src_min);
-
-	  trg_levels_s.push_back(trg_min);
-
-	  if(verbose){
-		std::cout<<"[ min ] "<<src_levels_s[0]<<" => "<<trg_levels_s[0]<<std::endl;
-		std::cout << "nr tgt samples: " << trg_hist_s.NumberOfSamples() << ". nr src samples: " << src_hist_s.NumberOfSamples() << std::endl;
-		std::cout << "nr tgt bins: " << trg_hist_s.NumberOfBins() << ". nr src bins: " << src_hist_s.NumberOfBins() << std::endl;
-		for(int i = 0 ; i < src_hist_s.NumberOfBins(); i++){
-
-		}
-	  }
-
-
-
-	  for(int i=0;i<=steps;i++)
-	  {
-		double pct =  i * step + cut_off/100;
-
-		double src_lev_s=src_hist_s.CDFToVal(pct);
-		double trg_lev_s=trg_hist_s.CDFToVal(pct);
-
-		if(verbose)
-			std::cout << "step " << i << " perc: " << pct << " src perc: " << src_lev_s << " trg perc: " << trg_lev_s << std::endl;
-
-		if(trg_lev_s-trg_levels_s[trg_levels_s.size()-1]<(trg_max-trg_min)/100000.0)
-		{
-		  std::cerr<<"Warning: "<<pct*100<<" percentile collapses in target, skipping"<<std::endl;
+	//provide mapping for background
+  Array<double> src_levels_s;
+  Array<double> trg_levels_s;
+	src_levels_s.push_back(src_min);
+	trg_levels_s.push_back(trg_min);
+  if (verbose) {
+    cout << "[ min ] " << src_levels_s[0] << " => " << trg_levels_s[0] << endl;
+    cout << "nr tgt samples: " << trg_hist_s.NumberOfSamples() << ". nr src samples: " << src_hist_s.NumberOfSamples() << endl;
+    cout << "nr tgt bins: " << trg_hist_s.NumberOfBins() << ". nr src bins: " << src_hist_s.NumberOfBins() << endl;
+  }
+	for (int i = 0; i <= steps; ++i) {
+		double pct =  i * step + cut_off/100.;
+		double src_lev_s = src_hist_s.CDFToVal(pct);
+		double trg_lev_s = trg_hist_s.CDFToVal(pct);
+    if (verbose) {
+      cout << "step " << i << " perc: " << pct << " src perc: " << src_lev_s << " trg perc: " << trg_lev_s << endl;
+    }
+		if (trg_lev_s-trg_levels_s[trg_levels_s.size()-1]<(trg_max-trg_min)/100000.0) {
+		  cerr << "Warning: " << pct*100 <<" percentile collapses in target, skipping" << endl;
 		} else {
-
 		  src_levels_s.push_back(src_lev_s);
 		  trg_levels_s.push_back(trg_lev_s);
-
-		  if(verbose)
-			std::cout<<"[ "<<pct*100.0<<" ] "<<src_levels_s[src_levels_s.size()-1]<<" => "<<trg_levels_s[trg_levels_s.size()-1]<<std::endl;
+      if (verbose) {
+        cout << "[ " << pct*100.0 << " ] " << src_levels_s[src_levels_s.size() - 1] << " => " << trg_levels_s[trg_levels_s.size() - 1] << endl;
+      }
 		}
-	  }
-	  //provide mapping for upper range
-
-	  src_levels_s.push_back(src_max);
-	  trg_levels_s.push_back(trg_max);
-
-
-	if(verbose)
-		std::cout<<"[ max ] "<<src_levels_s[src_levels_s.size()-1]<<" => "<<trg_levels_s[trg_levels_s.size()-1]<<std::endl;
-
-	if(verbose)
-		std::cout<<"Recalculating intensities..."<<std::flush;
-
-	RealPixel * ptr = _source.GetPointerToVoxels();
-
-	for(int i=0;i<_source.GetNumberOfVoxels();i++)
-	{
-	  //use LUT to map the intensities
-	  unsigned int bin;
-	  double input=*ptr;
-
-	  double output=input;
-	  for(bin=0;bin<src_levels_s.size();bin++)
-		if(input <= src_levels_s[bin]) break;
-
-	  if(input <= this->_source_padding)
-		  output = this->_source_padding;
-	  else if(bin==0) // first bin ?
-		  output=trg_levels_s[0];
-	  else if(bin>=(src_levels_s.size()-1))
-		  output=trg_levels_s[trg_levels_s.size()-1];
-	  else
-		  output=(input-src_levels_s[bin-1])
-		  /(src_levels_s[bin]-src_levels_s[bin-1])
-		  *(trg_levels_s[bin]-trg_levels_s[bin-1])+trg_levels_s[bin-1];
-
-//	  src.c_buf()[i]=output;
-	  *ptr = output;
-	  ptr++;
 	}
 
-	if(verbose)
-	  std::cout<<"Done!"<<std::endl;
+	//provide mapping for upper range
+	src_levels_s.push_back(src_max);
+	trg_levels_s.push_back(trg_max);
+  if (verbose) {
+    cout << "[ max ] " << src_levels_s[src_levels_s.size() - 1] << " => " << trg_levels_s[trg_levels_s.size() - 1] << endl;
+  }
+  if (verbose) {
+    cout << "Recalculating intensities..." << flush;
+  }
+	RealPixel *ptr = _source.GetPointerToVoxels();
+	for (int i = 0; i < _source.GetNumberOfVoxels(); ++i, ++ptr) {
+	  //use LUT to map the intensities
+	  double input  = *ptr;
+	  double output = input;
+    size_t bin;
+    for (bin = 0; bin < src_levels_s.size(); bin++) {
+      if (input <= src_levels_s[bin]) break;
+    }
+    if (input <= this->_source_padding) {
+      output = this->_source_padding;
+    } else if (bin == 0) { // first bin ?
+      output = trg_levels_s[0];
+    } else if (bin >= (src_levels_s.size() - 1)) {
+		  output = trg_levels_s[trg_levels_s.size()-1];
+    } else {
+      output = (input - src_levels_s[bin - 1])
+             / (src_levels_s[bin] - src_levels_s[bin - 1])
+             *(trg_levels_s[bin] - trg_levels_s[bin - 1]) + trg_levels_s[bin - 1];
+    }
+	  *ptr = output;
+	}
+  if (verbose) {
+    cout << " done" << endl;
+  }
 }
 
-}
+
+} // namespace mirtk

--- a/src/ProbabilisticAtlas.cc
+++ b/src/ProbabilisticAtlas.cc
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-
-#include "mirtk/Image.h"
-
 #include "mirtk/ProbabilisticAtlas.h"
+#include "mirtk/GenericImage.h"
+
 
 namespace mirtk {
+
 
 ProbabilisticAtlas::ProbabilisticAtlas()
 {
@@ -34,7 +34,7 @@ void ProbabilisticAtlas::SwapImages(int a, int b)
 {
 	if( a >= _number_of_tissues || b >= _number_of_tissues )
 	{
-		std::cerr << "cannot swap images, index out of bounds!" << std::endl;
+		cerr << "cannot swap images, index out of bounds!" << endl;
 		return;
 	}
 	RealImage tmpimage = _images[a];
@@ -51,13 +51,13 @@ void ProbabilisticAtlas::AddImage(RealImage image)
 		_number_of_voxels = image.GetNumberOfVoxels();
 	} else {
 		if (_number_of_voxels != image.GetNumberOfVoxels()) {
-			std::cerr << "Image sizes mismatch" << std::endl;
+			cerr << "Image sizes mismatch" << endl;
 			exit(1);
 		}
 	}
 	_images.push_back(image);
 	_pointers.push_back(image.GetPointerToVoxels());
-	_number_of_tissues = _images.size();
+	_number_of_tissues = static_cast<int>(_images.size());
 }
 
 void ProbabilisticAtlas::NormalizeAtlas(RealImage background)
@@ -67,11 +67,11 @@ void ProbabilisticAtlas::NormalizeAtlas(RealImage background)
 
 	// Add extra image
 	if (_number_of_tissues == 0) {
-		std::cerr << "ProbabilisticAtlas::NormalizeAtlas: No probability maps found" << std::endl;
+		cerr << "ProbabilisticAtlas::NormalizeAtlas: No probability maps found" << endl;
 		exit(1);
 	} else {
 		this->AddImage(background);
-		_number_of_tissues = _images.size();
+		_number_of_tissues = static_cast<int>(_images.size());
 
 	}
 
@@ -101,10 +101,10 @@ void ProbabilisticAtlas::NormalizeAtlas()
 
 	// Add extra image
 	if (_number_of_tissues == 0) {
-		std::cerr << "ProbabilisticAtlas::NormalizeAtlas: No probability maps found" << std::endl;
+		cerr << "ProbabilisticAtlas::NormalizeAtlas: No probability maps found" << endl;
 		exit(1);
 	}
-	_number_of_tissues = _images.size();
+	_number_of_tissues = static_cast<int>(_images.size());
 
 
 	// normalize atlas to 0 to 1
@@ -112,11 +112,9 @@ void ProbabilisticAtlas::NormalizeAtlas()
 	for (i = 0; i < _number_of_voxels; i++) {
 		norm = 0;
 
-		for (j = 0; j < _number_of_tissues-1; j++)
-		{
-			if( *(_pointers[j]) < .0 )
-			{
-				//std::cerr << " atlas prob < 0: " << *(_pointers[j]) << "  tissue " << j << " voxel" << i << std::endl;
+		for (j = 0; j < _number_of_tissues-1; j++) {
+			if (*(_pointers[j]) < .0) {
+				//cerr << " atlas prob < 0: " << *(_pointers[j]) << "  tissue " << j << " voxel" << i << endl;
 				*(_pointers[j]) = .0;
 			}
 		}
@@ -125,19 +123,19 @@ void ProbabilisticAtlas::NormalizeAtlas()
 			norm += *(_pointers[j]);
 		}
 		if (norm>0) {
-			for (j = 0; j < _number_of_tissues; j++)
-				*(_pointers[j]) = *(_pointers[j])/norm;
+      for (j = 0; j < _number_of_tissues; j++) {
+        *(_pointers[j]) = *(_pointers[j]) / norm;
+      }
 		} else {
-
 			int vx,vy,vz;
 			int index=i;
 			vz = index / (_images[0].GetX() * _images[0].GetY());
 			index -= vz * (_images[0].GetX() * _images[0].GetY());
 			vx = index % _images[0].GetX();
 			vy = index / _images[0].GetX();
-
-			for (j = 0; j < _number_of_tissues; j++)
-				*(_pointers[j]) = 0;
+      for (j = 0; j < _number_of_tissues; j++) {
+        *(_pointers[j]) = 0;
+      }
 		}
 		this->Next();
 	}
@@ -151,19 +149,18 @@ void ProbabilisticAtlas::AddBackground()
 
 	// Add extra image
 	if (_number_of_tissues == 0) {
-		std::cerr << "ProbabilisticAtlas::AddBackground: No probability maps found" << std::endl;
+		cerr << "ProbabilisticAtlas::AddBackground: No probability maps found" << endl;
 		exit(1);
 	} else {
 		this->AddImage(_images[0]);
-		_number_of_tissues = _images.size();
-
+		_number_of_tissues = static_cast<int>(_images.size());
 	}
 
 	// normalize atlas to 0 to 1
 	RealImage other;
 	other = _images[0];
 	for (i = 1; i < _number_of_tissues-1; i++) {
-		std::cerr<<i<<std::endl;
+		cerr<<i<<endl;
 		other += _images[i];
 	}
 	other.GetMinMax(&min, &max);
@@ -185,10 +182,7 @@ void ProbabilisticAtlas::AddBackground()
 
 void ProbabilisticAtlas::AddProbabilityMaps(int n, RealImage **atlas)
 {
-	int i;
-
-	for (i = 0; i < n; i++) {
-		// std::cout<<"adding image "<<i<<std::endl;
+	for (int i = 0; i < n; i++) {
 		this->AddImage(*(atlas[i]));
 	}
 };
@@ -196,34 +190,29 @@ void ProbabilisticAtlas::AddProbabilityMaps(int n, RealImage **atlas)
 void ProbabilisticAtlas::Write(int i, const char *filename)
 {
 	if  (i < _number_of_tissues) {
-		//_images[i] *= 255;
 		_images[i].Write(filename);
-		//_images[i] /= 255;
 	} else {
-		std::cerr << "ProbabilisticAtlas::Write: No such probability map" << std::endl;
+		cerr << "ProbabilisticAtlas::Write: No such probability map" << endl;
 		exit(1);
 	}
 }
 
 RealImage ProbabilisticAtlas::ComputeHardSegmentation()
 {
-	std::cerr<<"ProbabilisticAtlas::ComputeHardSegmentation"<<std::endl;
-	int i, tissue, j=0;
-	double max = 0;
+	int tissue;
+	double max;
 	_segmentation = _images[0];
 	First();
 	RealPixel *ptr = _segmentation.GetPointerToVoxels();
-
-	for (i = 0; i < _number_of_voxels; i++) {
-		max=0;
+	for (int i = 0; i < _number_of_voxels; ++i) {
+		max = 0.;
 		tissue = -1;
-		for (j=0; j< GetNumberOfTissues(); j++) {
+		for (int j = 0; j < GetNumberOfTissues(); ++j) {
 			if (GetValue(j) > max) {
 				tissue = j;
 				max = GetValue(j);
 			}
 		}
-
 		*ptr = tissue;
 		Next();
 		ptr++;
@@ -238,14 +227,9 @@ RealImage ProbabilisticAtlas::GetImage(int i)
 
 void ProbabilisticAtlas::ExtractLabel(int label, RealImage& image)
 {
-	std::cerr<<"ProbabilisticAtlas::ExtractLabel"<<std::endl;
-	int i;
-	//ComputeHardSegmentation();
-
 	RealPixel *ptr = _segmentation.GetPointerToVoxels();
 	RealPixel *ptr_im = image.GetPointerToVoxels();
-
-	for (i = 0; i < _number_of_voxels; i++) {
+	for (int i = 0; i < _number_of_voxels; ++i) {
 		if (*ptr == label) *ptr_im = 1;
 		else *ptr_im = 0;
 		ptr++;
@@ -258,4 +242,5 @@ void ProbabilisticAtlas::WriteHardSegmentation(const char *filename)
 	_segmentation.Write(filename);
 }
 
-}
+
+} // namespace mirtk

--- a/tools/calculate-gradients.cc
+++ b/tools/calculate-gradients.cc
@@ -168,15 +168,16 @@ int main(int argc, char **argv)
 	output.Write(output_name);
 
 	if (sepBasename != NULL){
-		char buffer[250];
+    const size_t bufsz = 256;
+		char buffer[bufsz];
 
-		sprintf(buffer, "%s-x.nii.gz", sepBasename);
+		snprintf(buffer, bufsz, "%s-x.nii.gz", sepBasename);
 		gradX.Write(buffer);
 
-		sprintf(buffer, "%s-y.nii.gz", sepBasename);
+		snprintf(buffer, bufsz, "%s-y.nii.gz", sepBasename);
 		gradY.Write(buffer);
 
-		sprintf(buffer, "%s-z.nii.gz", sepBasename);
+		snprintf(buffer, bufsz, "%s-z.nii.gz", sepBasename);
 		gradZ.Write(buffer);
 
 	}

--- a/tools/change-label.cc
+++ b/tools/change-label.cc
@@ -71,9 +71,9 @@ int main(int argc, char **argv)
 	img.Read(POSARG(1));
 	mask.Read(POSARG(2));
 
-	int N=atoi(POSARG(3));
-	int labels[N];
-	RealImage *probs = new RealImage[N];
+	const int N=atoi(POSARG(3));
+	Array<int> labels(N);
+	Array<RealImage> probs(N);
 
 	int a=4;
 	for(int i=0;i<N;i++){
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 
 	bool calcprobs=false;
 	RealImage prob;
-	string *outputprobs = new string[N];
+  Array<string> outputprobs(N);
 	if(a < NUM_POSARGS){
 		calcprobs=true;
 		prob.Read(POSARG(a)); a++;
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 	}
 
 
-
+  Array<double> vals(N);
 	for (x = 0; x < img.GetX(); x++) {
 		for (y = 0; y < img.GetY(); y++) {
 			for (z = 0; z < img.GetZ(); z++) {
@@ -106,8 +106,7 @@ int main(int argc, char **argv)
 
 				double maxval=0.0, sum=0.0, newprob=0.0;
 				int maxlabel=0;
-				double vals[N];
-
+        
 				for(int i=0;i<N;i++){
 					vals[i]=probs[i].Get(x,y,z);
 					if(vals[i]>maxval){
@@ -136,9 +135,6 @@ int main(int argc, char **argv)
 	if(calcprobs){
 		for(int i=0;i<N;i++) probs[i].Write(outputprobs[i].c_str());
 	}
-
-	delete[] probs;
-	delete[] outputprobs;
 
 	return 0;
 }

--- a/tools/draw-em.cc
+++ b/tools/draw-em.cc
@@ -566,7 +566,7 @@ int main(int argc, char **argv)
 		bias.Write(output_biasfield);
 	}
 
-	for( unsigned int i = 0; i < ss; ++i ){
+	for (int i = 0; i < ss; ++i) {
 		std::cout<<"saving probability map of structure "<<savesegsnr[i]<<" to "<<savesegs[i]<<std::endl;
 		classification->WriteProbMap(savesegsnr[i],savesegs[i].c_str());
 	}
@@ -576,7 +576,7 @@ int main(int argc, char **argv)
 
 
 	clock_t end = clock();
-	int elapsed_secs = round( double(end - begin) / CLOCKS_PER_SEC);
+	int elapsed_secs = iround( double(end - begin) / CLOCKS_PER_SEC);
 	int elapsed_mins = elapsed_secs/60;
 	elapsed_secs%=elapsed_mins;
 	std::cout<<"elapsed time: "<<elapsed_mins<<" min "<<elapsed_secs<<" sec"<<std::endl;

--- a/tools/em-hard-segmentation.cc
+++ b/tools/em-hard-segmentation.cc
@@ -83,8 +83,8 @@ double getMRFenergyTerm(int x, int y, int z, int k)
 
 
 void MRFStep(){
-	double mrfterms[n];
-	double numerator[n];
+	Array<double> mrfterms(n);
+	Array<double> numerator(n);
 	double denominator;
         for(int x = 0; x < maxx; x++){
           for(int y = 0; y < maxy; y++){

--- a/tools/em.cc
+++ b/tools/em.cc
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
 	segmentation.Write(output_name);
 
 
-	for( unsigned int i = 0; i < ss; ++i ){
+	for (int i = 0; i < ss; ++i) {
 		std::cout<<"saving probability map of structure "<<savesegsnr[i]<<" to "<<savesegs[i]<<std::endl;
 		classification->WriteProbMap(savesegsnr[i],savesegs[i].c_str());
 	}

--- a/tools/fill-holes-nn-based.cc
+++ b/tools/fill-holes-nn-based.cc
@@ -90,12 +90,12 @@ int main(int argc, char **argv){
     cc.Output(&suspectedcc);
     cc.Run();
 
-    int numccs=cc.NumberOfComponents();
-    int numccNNs[numccs];
-    int numccMaskNNs[numccs];
+    const int numccs=cc.NumberOfComponents();
+    Array<int> numccNNs(numccs);
+    Array<int> numccMaskNNs(numccs);
     for(int i=0; i<numccs; i++){
-	numccNNs[i]=0;
-	numccMaskNNs[i]=0;
+      numccNNs[i]=0;
+      numccMaskNNs[i]=0;
     }
 
 
@@ -146,9 +146,10 @@ int main(int argc, char **argv){
 	}
     }
 
-    bool fill[numccs];
-    for(int i=0; i<numccs; i++)
-	fill[i]=( ((double)numccMaskNNs[i]/(double)numccNNs[i]) >= majority);
+    Array<bool> fill(numccs);
+    for (int i = 0; i < numccs; i++) {
+      fill[i] = (((double)numccMaskNNs[i] / (double)numccNNs[i]) >= majority);
+    }
 	
 
     GreyPixel *p=image.GetPointerToVoxels();

--- a/tools/kmeans.cc
+++ b/tools/kmeans.cc
@@ -126,7 +126,7 @@ int main(int argc, char **argv){
 	}
 
 	int i=0;
-	double * intensities=new double[numintensities];
+	Array<double> intensities(numintensities);
 	double sumintensities=0;
 	for(int x = 0; x < input.GetX(); x++){
 		for(int y = 0; y < input.GetY(); y++){
@@ -140,7 +140,7 @@ int main(int argc, char **argv){
 		}
 	}
 
-	kmeans km(intensities,numintensities,k,iterations,replicates);
+	kmeans km(intensities.data(),numintensities,k,iterations,replicates);
 	int *intensitiesCentroids=km.getPointClusters();
 
 
@@ -164,10 +164,9 @@ int main(int argc, char **argv){
 
 	if (probsBase != NULL){
 		double *centroids=km.getCentroids();
-		double *vars=new double[k];
-		double *denom=new double[k];
-		Gaussian *G=new Gaussian[k];
-
+		Array<double> vars(k);
+    Array<double> denom(k);
+		Array<Gaussian> G(k);
 
 		for (i=0;i<k;i++){ 
 			denom[i]=0;
@@ -183,13 +182,14 @@ int main(int argc, char **argv){
 		}
 
 
-		RealImage *probs = new RealImage[k];
+		Array<RealImage> probs(k);
 		for (int i = 0; i < k; i++){
 			probs[i].Initialize (input.GetImageAttributes());
 			G[i].Initialise (centroids[i], vars[i]);
 		}
 
-		double val, probval[k];
+    double val;
+    Array<double> probval(k);
 		for(int x = 0; x < input.GetX(); x++){
 			for(int y = 0; y < input.GetY(); y++){
 				for(int z = 0; z < input.GetZ(); z++){
@@ -205,9 +205,7 @@ int main(int argc, char **argv){
 							probval[i]/=sumprob;
 							probs[i].Put(x,y,z,0,probval[i]);
 						}
-
 					}
-
 				}
 			}
 		}
@@ -225,11 +223,6 @@ int main(int argc, char **argv){
 			probs[i].Write((ss.str()).c_str());
 			std::cout<<"c["<<i<<"]="<<centroids[i]<<" , "<<vars[i]<<std::endl;
 		}
-
-		delete[] probs;
-		delete[] vars;
-		delete[] G;
-		delete[] intensities;
 		delete[] centroids;
 	}
 

--- a/tools/normalize.cc
+++ b/tools/normalize.cc
@@ -30,20 +30,20 @@ using namespace mirtk;
 
 void PrintHelp(const char *name)
 {
-  std::cout << "usage: " << name << " <target> <source> <output_source> [options]" << std::endl;
-  std::cout << "       " << name << " <input> <output> -equalize <padding>" << std::endl;
-  std::cout << std::endl;
-  std::cout << "Normalizes the intensity distribution of an image to be similar to" << std::endl;
-  std::cout << "the intensity distribution of a given reference image. Moreover," << std::endl;
-  std::cout << "this tool can be used to equalize the histograms of either a single" << std::endl;
-  std::cout << "given image or two images using the same transfer function." << std::endl;
-  std::cout << std::endl;
-  std::cout << "Options:" << std::endl;
-  std::cout << "  -Tp <value>   Target padding value" << std::endl;
-  std::cout << "  -Sp <value>   Source padding value" << std::endl;
-  std::cout << "  -piecewise    Use a piecewise linear function as suggested by Nyul et al." << std::endl;
-  std::cout << "  -equalize <padding> [<target_output>]   Equalize histograms before normalization." << std::endl;
-  PrintCommonOptions(std::cout);
+  cout << "usage: " << name << " <target> <source> <output_source> [options]" << endl;
+  cout << "       " << name << " <input> <output> -equalize <padding>" << endl;
+  cout << endl;
+  cout << "Normalizes the intensity distribution of an image to be similar to" << endl;
+  cout << "the intensity distribution of a given reference image. Moreover," << endl;
+  cout << "this tool can be used to equalize the histograms of either a single" << endl;
+  cout << "given image or two images using the same transfer function." << endl;
+  cout << endl;
+  cout << "Options:" << endl;
+  cout << "  -Tp <value>   Target padding value" << endl;
+  cout << "  -Sp <value>   Source padding value" << endl;
+  cout << "  -piecewise    Use a piecewise linear function as suggested by Nyul et al." << endl;
+  cout << "  -equalize <padding> [<target_output>]   Equalize histograms before normalization." << endl;
+  PrintCommonOptions(cout);
 }
 
 int main(int argc, char **argv)
@@ -101,14 +101,14 @@ int main(int argc, char **argv)
   // Read input image(s)
   RealImage target;
   if (target_name) {
-    if (verbose) std::cout << "Reading target image ... ", std::cout.flush();
+    if (verbose) cout << "Reading target image ... ", cout.flush();
     target.Read(target_name);
-    if (verbose) std::cout << "done" << std::endl;
+    if (verbose) cout << "done" << endl;
   }
 
-  if (verbose) std::cout << "Reading source image ... ", std::cout.flush();
+  if (verbose) cout << "Reading source image ... ", cout.flush();
   RealImage source(source_name);
-  if (verbose) std::cout << "done" << std::endl;
+  if (verbose) cout << "done" << endl;
 
   // Equalize histograms
   if (equalize) {
@@ -116,8 +116,8 @@ int main(int argc, char **argv)
     RealImage *reference = (target.IsEmpty() ? &source : &target);
 
     if (verbose) {
-      std::cout << "Equalize histogram" << ((reference == &target) ? "s" : "") << " ... ";
-      std::cout.flush();
+      cout << "Equalize histogram" << ((reference == &target) ? "s" : "") << " ... ";
+      cout.flush();
     }
 
     reference->GetMinMaxAsDouble(min, max);
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
       histogram.BackProject(&source);
     }
 
-    if (verbose) std::cout << "done" << std::endl;
+    if (verbose) cout << "done" << endl;
   }
 
   // Stop if source image equalization is done only
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
     return 0;
   }
 
-  if (verbose) std::cout << "Normalize histogram ... ";
+  if (verbose) cout << "Normalize histogram ... ";
 
   // Normalize histogram
   if (piecewise) {
@@ -157,6 +157,7 @@ int main(int argc, char **argv)
     source = nn.GetOutput();
   } else {
     double a, b, cov, var, x_avg, y_avg, x, y, z;
+    int u, v, w;
 
 	  int n = 0;
 	  x_avg = 0;
@@ -167,20 +168,20 @@ int main(int argc, char **argv)
       x = i; y = j; z = k;
       source.ImageToWorld(x,y,z);
       target.WorldToImage(x,y,z);
-      x = round(x); y = round(y); z = round(z);
-      if (x >= 0 && x < target.GetX() &&
-          y >= 0 && y < target.GetY() &&
-          z >= 0 && z < target.GetZ()) {
-        if ((source(i, j, k) > source_padding) && (target(x,y,z) > target_padding)) {
+      u = iround(x);
+      v = iround(y);
+      w = iround(z);
+      if (target.IsInside(u, v, w)) {
+        if ((source(i, j, k) > source_padding) && (target(u, v, w) > target_padding)) {
           n++;
           x_avg += source(i, j, k);
-          y_avg += target(x, y, z);
+          y_avg += target(u, v, w);
         }
       }
 	  }
 	  if (n == 0) {
-      std::cout << "failed" << std::endl;
-      std::cerr << EXECNAME << ": Number of samples should be larger than zero" << std::endl;
+      cout << "failed" << endl;
+      cerr << EXECNAME << ": Number of samples should be larger than zero" << endl;
       exit(1);
 	  }
 
@@ -192,12 +193,12 @@ int main(int argc, char **argv)
       x = i; y = j; z = k;
       source.ImageToWorld(x,y,z);
       target.WorldToImage(x,y,z);
-      x = round(x); y = round(y); z = round(z);
-      if (x >= 0 && x < target.GetX() &&
-          y >= 0 && y < target.GetY() &&
-          z >= 0 && z < target.GetZ()) {
-        if ((source(i, j, k) > source_padding) && (target(x, y, z) > target_padding)) {
-          cov += (source(i, j, k) - x_avg) * (target(x, y, z) - y_avg);
+      u = iround(x);
+      v = iround(y);
+      w = iround(z);
+      if (target.IsInside(u, v, w)) {
+        if ((source(i, j, k) > source_padding) && (target(u, v, w) > target_padding)) {
+          cov += (source(i, j, k) - x_avg) * (target(u, v, w) - y_avg);
           var += (source(i, j, k) - x_avg) * (source(i, j, k) - x_avg);
         }
       }
@@ -208,7 +209,7 @@ int main(int argc, char **argv)
 	  a = y_avg - b * x_avg;
 
     if (verbose) {
-      std::cout << "scaling = " << b << ", offset = " << b;
+      cout << "scaling = " << b << ", offset = " << b;
     }
 
 	  for (int k = 0; k < source.GetZ(); k++)
@@ -219,7 +220,7 @@ int main(int argc, char **argv)
       }
 	  }
 
-    if (verbose) std::cout << "done" << std::endl;
+    if (verbose) cout << "done" << endl;
   }
 
   // Write normalized image

--- a/tools/padding.cc
+++ b/tools/padding.cc
@@ -87,8 +87,8 @@ int main(int argc, char **argv)
 	unique_ptr<BaseImage> inputA(BaseImage::New(inputA_name));
 	unique_ptr<BaseImage> inputB(BaseImage::New(inputB_name));
 
-	int x, y, z, t;
-	double i, j, k;
+	int x, y, z, i, j, k, t;
+	double u, v, w;
 	vector<int> numvalues;
 	vector<double*> values;
 	vector<double> padding;
@@ -167,16 +167,11 @@ int main(int argc, char **argv)
 		for (z = 0; z < inputA->GetZ(); z++) {
 			for (y = 0; y < inputA->GetY(); y++) {
 				for (x = 0; x < inputA->GetX(); x++) {
-					i = x; j = y; k = z;
-					inputA->ImageToWorld(i,j,k);
-					inputB->WorldToImage(i,j,k);
-					i = round(i); j = round(j); k = round(k);
-
-					if (! (i >= 0 && i < inputB->GetX()
-							&& j >= 0 && j < inputB->GetY()
-							&& k >= 0 && k < inputB->GetZ()
-							&& t >= 0 && t < inputB->GetT()) ) continue;
-
+          u = x, v = y, w = z;
+					inputA->ImageToWorld(u, v, w);
+					inputB->WorldToImage(u, v, w);
+          i = iround(u), j = iround(v), k = iround(w);
+					if (!inputB->IsInside(i, j, k, t)) continue;
 
 					double val=inputB->GetAsDouble(i, j, k, t);
 					for(int s=0; s<setsvalues; s++){

--- a/tools/split-labels.cc
+++ b/tools/split-labels.cc
@@ -76,7 +76,7 @@ int main(int argc, char **argv){
 	// structures
 	int numStructuresToDo= atoi(POSARG(a)); a++;
 	string *names = new string[numStructuresToDo];
-	int values[numStructuresToDo];
+	Array<int> values(numStructuresToDo);
 	for(int j = 0; j < numStructuresToDo; j++){
 		values[j] = atoi(POSARG(a)); a++;
 	}


### PR DESCRIPTION
Fixes build with VC on Windows. Use `mirtk::Array` (aka `std::vector`) for dynamically allocated arrays. Fix implicit type cast warnings. Remove `std::` from `std::cout`, `std::cerr`, and `std::endl` in some cases (not all yet).

@amakropoulos Could you please verify that the programs still work fine as expected after this change?

Closes #16.