### PR TITLE
Add DrawEM_BUILD_N4 and DrawEM_ATLASES options

### DIFF
--- a/Atlases.cmake
+++ b/Atlases.cmake
@@ -1,23 +1,31 @@
-cmake_minimum_required(VERSION 2.7)
+set(ATLASES_URL "https://biomedic.doc.ic.ac.uk/brain-development/downloads/dHCP/atlases-dhcp-structural-pipeline-v1.zip")
+set(ATLASES_MD5 "77e924bc17a4906f5814874009f5eca6")
+set(ATLASES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/atlases")
 
-include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
+set(_default ON)
+if (IS_DIRECTORY "${ATLASES_DIR}")
+  set(_default OFF)
+endif ()
+option(DrawEM_ATLASES "Whether to download DrawEM atlases during build step" ${_default})
+unset(_default)
 
-set(ATLAS_URL "https://biomedic.doc.ic.ac.uk/brain-development/downloads/dHCP/atlases-dhcp-structural-pipeline-v1.zip")
-set(ATLAS_MD5 77e924bc17a4906f5814874009f5eca6)
+if (DrawEM_ATLASES)
 
-if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/atlases)
-    ExternalProject_Add(atlases
-      URL ${ATLAS_URL}
-      URL_MD5 ${ATLAS_MD5}
-      PREFIX atlases
-      CONFIGURE_COMMAND ""
-      BUILD_COMMAND ""
-      INSTALL_COMMAND ""
-    )
+  include(ExternalProject)
 
-    add_custom_target(atlases_move ALL
-      ${CMAKE_COMMAND} -E rename ${CMAKE_CURRENT_BINARY_DIR}/atlases/src/atlases ${CMAKE_CURRENT_SOURCE_DIR}/atlases
-    )
+  ExternalProject_Add(atlases
+    URL ${ATLASES_URL}
+    URL_MD5 ${ATLASES_MD5}
+    PREFIX atlases
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
 
-    ADD_DEPENDENCIES(atlases_move atlases)
-endif()
+  ExternalProject_Add_Step(atlases rename
+    COMMAND ${CMAKE_COMMAND} -E rename "${CMAKE_CURRENT_BINARY_DIR}/atlases/src/atlases" "${ATLASES_DIR}"
+    COMMENT "Move extracted atlases to source directory"
+    DEPENDEES download
+  )
+
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,5 +26,9 @@ endif ()
 
 mirtk_configure_module()
 
-add_subdirectory(ThirdParty/ANTs)
+option(DrawEM_BUILD_N4 "Whether to build ANTs N4 from sources included in DrawEM" ON)
+if (DrawEM_BUILD_N4)
+  add_subdirectory(ThirdParty/ANTs)
+endif()
+
 include(Atlases.cmake)


### PR DESCRIPTION
Use ExternalProject_Add_Step instead of add_custom_command to move extracted folder.

Trying to fix Travis CI build error: https://travis-ci.org/BioMedIA/MIRTK/jobs/628798912#L3364

Added options `DrawEM_BUILD_N4` and `DrawEM_ATLASES` which would allow me to disable these steps during Travis CI builds.