### PR TITLE
Require CMake 2.8.12 as minimum versions, older versions are deprecated

### DIFF
--- a/ThirdParty/ANTs/CMakeLists.txt
+++ b/ThirdParty/ANTs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.7)
+cmake_minimum_required(VERSION 2.8.12)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0046 NEW)
   cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
```
CMake Deprecation Warning at Packages/DrawEM/ThirdParty/ANTs/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
